### PR TITLE
Fixed dark theme editor background color

### DIFF
--- a/library/src/main/java/de/markusressel/kodeeditor/library/view/CodeEditorLayout.kt
+++ b/library/src/main/java/de/markusressel/kodeeditor/library/view/CodeEditorLayout.kt
@@ -282,7 +282,8 @@ constructor(
         editorBackgroundColor = a.getColor(context,
                 defaultColor = Color.WHITE,
                 styleableRes = R.styleable.CodeEditorLayout_ke_editor_backgroundColor,
-                attr = intArrayOf(R.attr.ke_editor_backgroundColor))
+                attr = intArrayOf(R.attr.ke_editor_backgroundColor,
+                        android.R.attr.windowBackground))
         codeEditorView.setBackgroundColor(editorBackgroundColor)
         isMoveWithCursorEnabled = a.getBoolean(R.styleable.CodeEditorLayout_ke_editor_followCursor, true)
 


### PR DESCRIPTION
When using the view on a dark theme system, editor background was white. I fixed it adding `android.R.attr.windowBackground` in default values, as said in the documentation.

![image](https://user-images.githubusercontent.com/30439790/119276542-0d682500-bc1b-11eb-9366-5ae8ad5eddee.png)
