### PR TITLE
Fixed two other missing default colors

### DIFF
--- a/library/src/main/java/de/markusressel/kodeeditor/library/view/CodeEditorLayout.kt
+++ b/library/src/main/java/de/markusressel/kodeeditor/library/view/CodeEditorLayout.kt
@@ -260,7 +260,8 @@ constructor(
         val lineNumberTextColor = a.getColor(context,
                 defaultColor = Color.BLACK,
                 styleableRes = R.styleable.CodeEditorLayout_ke_lineNumbers_textColor,
-                attr = intArrayOf(R.attr.ke_lineNumbers_textColor))
+                attr = intArrayOf(R.attr.ke_lineNumbers_textColor,
+                        android.R.attr.textColorPrimary))
         lineNumberTextView.setTextColor(lineNumberTextColor)
 
         val lineNumberBackgroundColor = a.getColor(context,
@@ -276,7 +277,8 @@ constructor(
         val dividerColor = a.getColor(context,
                 defaultColor = Color.BLACK,
                 styleableRes = R.styleable.CodeEditorLayout_ke_divider_color,
-                attr = intArrayOf(R.attr.ke_divider_color))
+                attr = intArrayOf(R.attr.ke_divider_color,
+                        android.R.attr.textColorPrimary))
         dividerView.setBackgroundColor(dividerColor)
 
         editorBackgroundColor = a.getColor(context,


### PR DESCRIPTION
Updating to `4.0.0`, I noticed that two other defaults are missing... so adding them in code.

![image](https://user-images.githubusercontent.com/30439790/119349111-0df5cf80-bc9e-11eb-9855-cf7e23dd0cf1.png)
![image](https://user-images.githubusercontent.com/30439790/119348949-cd965180-bc9d-11eb-94b0-5a3fd393fc5e.png)

(And this time I checked all colors, no others are missing)